### PR TITLE
Implemented @arvindpunk's idea (disclose path)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,15 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>JIIT Open Dev Circle</title>
-	<link rel="icon" type="image/ico" href="images/logo.jpg" />
+	<link id="logo" rel="icon" type="image/ico" href="" />
 	<link rel="stylesheet" href="css/style.css">
 	<link href="https://fonts.googleapis.com/css?family=Cabin+Sketch|Courgette|Roboto" rel="stylesheet">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css">
 	<script type="txt/javascript" src="js/custom.js"></script>
+	<script src="js/fetchLogo.js"></script>
 </head>
 
-<body>
+<body onload=this.loadLogo()>
 
 	<div class="container">
 

--- a/js/fetchLogo.js
+++ b/js/fetchLogo.js
@@ -5,11 +5,10 @@ const URL = 'https://preview.ibb.co/n0YRaf/logo.jpg'
 fetch(URL).then(
     data => {
         sessionStorage.setItem('logoURL',data.url)
+        let source = sessionStorage.getItem('logoURL')
+        document.getElementById('logo').href = source;
     }
 ).catch(console.error())
 
-let source = sessionStorage.getItem('logoURL')
-
-document.getElementById('logo').href = source;
-
+console.log('source fetched!')
 }

--- a/js/fetchLogo.js
+++ b/js/fetchLogo.js
@@ -1,0 +1,15 @@
+loadLogo = () => {
+
+const URL = 'https://preview.ibb.co/n0YRaf/logo.jpg'
+
+fetch(URL).then(
+    data => {
+        sessionStorage.setItem('logoURL',data.url)
+    }
+).catch(console.error())
+
+let source = sessionStorage.getItem('logoURL')
+
+document.getElementById('logo').href = source;
+
+}


### PR DESCRIPTION
I think fetching the required data (stylesheets and scripts) over the network would add to the site's security.
This also removes the need to store JODC's logo on this repo, hence not disclosing its path!
Have a look.

![js rendered hyperlink](https://user-images.githubusercontent.com/33557095/47217158-13435d00-d3c5-11e8-82db-2df2feb564a0.png)

Thanks @arvindpunk for the idea! Cheers!:clinking_glasses: