### PR TITLE
Set 'z-index' of '.topnav' to '1'.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -32,6 +32,7 @@ p {
 	position: fixed;
 	top: 0;
 	text-align: center;
+	z-index: 1;
 }
 
 .topnav a {


### PR DESCRIPTION
Fixes #50 
 Set the z-index of .topnav to 1 to help with the overlap. Most likely this is related to the 'fixed' property on the navigation bar.