### PR TITLE
(ci, feat) add github actions for prettier checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    # Run for any pushs on master
+    branches:
+      - master
+  # Run tests for any PRs.
+  pull_request:
+
+jobs:
+  run-tests:
+    name: Quality Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup node
+        uses: actions/setup-node@v1
+      - name: Install Packages
+        run: yarn install
+      - name: Run Prettier
+        run: yarn lint:check


### PR DESCRIPTION
Sets up prettier Github action per #45.

This should run on any PR and any push to the master branch. Further checks or criteria for running can be added.